### PR TITLE
feature!: migrate blobs on GCS

### DIFF
--- a/config/final.yml
+++ b/config/final.yml
@@ -2,6 +2,8 @@
 blobstore:
   provider: s3 
   options:
-    bucket_name: orange-node-hardening-boshrelease
+    bucket_name: s3selfcare-node-hardening-boshrelease
+    region: eu
+    host: storage.googleapis.com
 final_name: node-hardening
 


### PR DESCRIPTION
We move away from AWS to GCS. Releases prior to this one cannot be used anymore.